### PR TITLE
Updated nuxt-typed-router version to `3.1.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint": "^8.38.0",
     "nuxt": "^3.4.1",
     "nuxt-icon": "^0.3.3",
-    "nuxt-typed-router": "^3.1.3",
+    "nuxt-typed-router": "^3.1.4",
     "primeflex": "^3.3.0",
     "primeicons": "^6.0.1",
     "primevue": "^3.26.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,16 +13,16 @@ dependencies:
 devDependencies:
   '@nuxt/test-utils':
     specifier: ^3.4.1
-    version: 3.4.1(rollup@2.79.1)(vue@3.2.47)
+    version: 3.4.1(vue@3.2.47)
   '@nuxtjs/eslint-config-typescript':
     specifier: ^12.0.0
     version: 12.0.0(eslint@8.38.0)(typescript@5.0.4)
   '@nuxtjs/google-fonts':
     specifier: ^3.0.0
-    version: 3.0.0(rollup@2.79.1)
+    version: 3.0.0
   '@pinia/nuxt':
     specifier: ^0.4.8
-    version: 0.4.8(rollup@2.79.1)(typescript@5.0.4)(vue@3.2.47)
+    version: 0.4.8(typescript@5.0.4)(vue@3.2.47)
   '@pinia/testing':
     specifier: ^0.0.16
     version: 0.0.16(pinia@2.0.34)(vue@3.2.47)
@@ -37,10 +37,10 @@ devDependencies:
     version: 5.0.2
   '@vite-pwa/nuxt':
     specifier: ^0.0.7
-    version: 0.0.7(@nuxt/kit@3.4.1)(vite-plugin-pwa@0.14.7)
+    version: 0.0.7
   '@vue-macros/nuxt':
     specifier: ^1.2.8
-    version: 1.2.8(@vue-macros/reactivity-transform@0.3.4)(@vueuse/core@10.0.0)(nuxt@3.4.1)(rollup@2.79.1)(vite@4.2.1)(vue@3.2.47)
+    version: 1.2.8(@vueuse/core@10.0.0)(nuxt@3.4.1)(vue@3.2.47)
   '@vue/compiler-sfc':
     specifier: ^3.2.47
     version: 3.2.47
@@ -52,7 +52,7 @@ devDependencies:
     version: 10.0.0(vue@3.2.47)
   '@vueuse/nuxt':
     specifier: ^10.0.0
-    version: 10.0.0(nuxt@3.4.1)(rollup@2.79.1)(vue@3.2.47)
+    version: 10.0.0(nuxt@3.4.1)(vue@3.2.47)
   '@whoj/eslint-config':
     specifier: ^1.4.0
     version: 1.4.0(eslint@8.38.0)(typescript@5.0.4)
@@ -70,13 +70,13 @@ devDependencies:
     version: 8.38.0
   nuxt:
     specifier: ^3.4.1
-    version: 3.4.1(@types/node@18.15.11)(eslint@8.38.0)(rollup@2.79.1)(sass@1.62.0)(typescript@5.0.4)
+    version: 3.4.1(@types/node@18.15.11)(eslint@8.38.0)(sass@1.62.0)(typescript@5.0.4)
   nuxt-icon:
     specifier: ^0.3.3
-    version: 0.3.3(rollup@2.79.1)(vue@3.2.47)
+    version: 0.3.3(vue@3.2.47)
   nuxt-typed-router:
-    specifier: ^3.1.3
-    version: 3.1.3(rollup@2.79.1)
+    specifier: ^3.1.4
+    version: 3.1.4
   primeflex:
     specifier: ^3.3.0
     version: 3.3.0
@@ -140,29 +140,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core@7.20.12:
-    resolution: {integrity: sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.21.4
-      '@babel/generator': 7.21.4
-      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.20.12)
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helpers': 7.21.0
-      '@babel/parser': 7.21.4
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.4
-      '@babel/types': 7.21.4
-      convert-source-map: 1.9.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/core@7.21.4:
     resolution: {integrity: sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==}
     engines: {node: '>=6.9.0'}
@@ -209,20 +186,6 @@ packages:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
       '@babel/types': 7.21.4
-    dev: true
-
-  /@babel/helper-compilation-targets@7.21.4(@babel/core@7.20.12):
-    resolution: {integrity: sha512-Fa0tTuOXZ1iL8IeDFUWCzjZcn+sJGd9RZdH9esYVjEejGmzf+FFYQpMi/kZUk2kPy/q1H3/GPw7np8qar/stfg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.21.4
-      '@babel/core': 7.20.12
-      '@babel/helper-validator-option': 7.21.0
-      browserslist: 4.21.5
-      lru-cache: 5.1.1
-      semver: 6.3.0
     dev: true
 
   /@babel/helper-compilation-targets@7.21.4(@babel/core@7.21.4):
@@ -1774,11 +1737,11 @@ packages:
     resolution: {integrity: sha512-YBI/6o2EBz02tdEJRBK8xkt3zvOFOWlLBf7WKYGBsSYSRtjjgrqPe2skp6VLLmKx5WbHHDNcW+6oACaurxGzeA==}
     dev: true
 
-  /@nuxt/kit@3.1.2(rollup@2.79.1):
+  /@nuxt/kit@3.1.2:
     resolution: {integrity: sha512-m8/AF8hBJiG7aTx2CpiDGeLYYz30fUoPbJ9XiSmHqRIXv1goAFWHSkzWfRNEsoAAbMHf76oB917wVUQ3VSSQHg==}
     engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     dependencies:
-      '@nuxt/schema': 3.1.2(rollup@2.79.1)
+      '@nuxt/schema': 3.1.2
       c12: 1.1.0
       consola: 2.15.3
       defu: 6.1.2
@@ -1794,18 +1757,18 @@ packages:
       scule: 1.0.0
       semver: 7.3.8
       unctx: 2.1.1
-      unimport: 2.1.0(rollup@2.79.1)
+      unimport: 2.1.0
       untyped: 1.2.2
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: true
 
-  /@nuxt/kit@3.4.1(rollup@2.79.1):
+  /@nuxt/kit@3.4.1:
     resolution: {integrity: sha512-VeH26umZW6Rf4F1QX9nTIuTBp6HeL/MgmKY3+FgQiLD07afgFTLUJZohVE5xU7hb66zCnYvwKxa3JpjXFJZrhQ==}
     engines: {node: ^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     dependencies:
-      '@nuxt/schema': 3.4.1(rollup@2.79.1)
+      '@nuxt/schema': 3.4.1
       c12: 1.2.0
       consola: 3.0.2
       defu: 6.1.2
@@ -1821,14 +1784,14 @@ packages:
       scule: 1.0.0
       semver: 7.4.0
       unctx: 2.2.0
-      unimport: 3.0.6(rollup@2.79.1)
+      unimport: 3.0.6
       untyped: 1.3.2
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: true
 
-  /@nuxt/schema@3.1.2(rollup@2.79.1):
+  /@nuxt/schema@3.1.2:
     resolution: {integrity: sha512-wru9LhRXTa6WQlx7c0oYrtvJY7TiVlkBKXY5Rsmfo0StJuWohgZiReu9fu6z6GU4MzZlX25TVjwvq9Q7bNVbSQ==}
     engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     dependencies:
@@ -1843,14 +1806,14 @@ packages:
       scule: 1.0.0
       std-env: 3.3.2
       ufo: 1.1.1
-      unimport: 2.1.0(rollup@2.79.1)
+      unimport: 2.1.0
       untyped: 1.3.2
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: true
 
-  /@nuxt/schema@3.4.1(rollup@2.79.1):
+  /@nuxt/schema@3.4.1:
     resolution: {integrity: sha512-xhPh9JfVKXRQVfdUT6BKieDTCljBjbIGgGCQnxplVi4FUTWRKUXR7MFwsobr5D9AJpeE0mg5/kRRh5gUX37vAQ==}
     engines: {node: ^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     dependencies:
@@ -1865,18 +1828,18 @@ packages:
       scule: 1.0.0
       std-env: 3.3.2
       ufo: 1.1.1
-      unimport: 3.0.6(rollup@2.79.1)
+      unimport: 3.0.6
       untyped: 1.3.2
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: true
 
-  /@nuxt/telemetry@2.2.0(rollup@2.79.1):
+  /@nuxt/telemetry@2.2.0:
     resolution: {integrity: sha512-Z2UmPkBy5WjxvHKuUcl1X6vKWnIyWSP+9UGde1F+MzzZxYgAQybFud1uL2B3KCowxZdoqT1hd2WklV7EtyCwrQ==}
     hasBin: true
     dependencies:
-      '@nuxt/kit': 3.4.1(rollup@2.79.1)
+      '@nuxt/kit': 3.4.1
       chalk: 5.2.0
       ci-info: 3.8.0
       consola: 3.0.2
@@ -1901,14 +1864,14 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt/test-utils@3.4.1(rollup@2.79.1)(vue@3.2.47):
+  /@nuxt/test-utils@3.4.1(vue@3.2.47):
     resolution: {integrity: sha512-qKcFXZIbUKAoaYKoo4MfxzYdRh3BGPrl5zpS03nQXgr9iUK0Z9i08ukWURnxFR/Meky+FW3MnZvKhx7ISApeEw==}
     engines: {node: ^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     peerDependencies:
       vue: ^3.2.47
     dependencies:
-      '@nuxt/kit': 3.4.1(rollup@2.79.1)
-      '@nuxt/schema': 3.4.1(rollup@2.79.1)
+      '@nuxt/kit': 3.4.1
+      '@nuxt/schema': 3.4.1
       consola: 3.0.2
       defu: 6.1.2
       execa: 7.1.1
@@ -1927,14 +1890,14 @@ packages:
     resolution: {integrity: sha512-PjVETP7+iZXAs5Q8O4ivl4t6qjWZMZqwiTVogUXHoHGZZcw7GZW3u3tzfYfE1HbzyYJfr236IXqQ02MeR8Fz2w==}
     dev: true
 
-  /@nuxt/vite-builder@3.4.1(@types/node@18.15.11)(eslint@8.38.0)(rollup@2.79.1)(sass@1.62.0)(typescript@5.0.4)(vue@3.2.47):
+  /@nuxt/vite-builder@3.4.1(@types/node@18.15.11)(eslint@8.38.0)(sass@1.62.0)(typescript@5.0.4)(vue@3.2.47):
     resolution: {integrity: sha512-qqS+hUv91z58vLNEorP4xfyvo/uoteTCYaMouyRZzqnJhrE/G82x2SqdzfADEhKpNHUkGWhpc37uuejrM+y6qw==}
     engines: {node: ^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     peerDependencies:
       vue: ^3.2.47
     dependencies:
-      '@nuxt/kit': 3.4.1(rollup@2.79.1)
-      '@rollup/plugin-replace': 5.0.2(rollup@2.79.1)
+      '@nuxt/kit': 3.4.1
+      '@rollup/plugin-replace': 5.0.2
       '@vitejs/plugin-vue': 4.1.0(vite@4.2.1)(vue@3.2.47)
       '@vitejs/plugin-vue-jsx': 3.0.1(vite@4.2.1)(vue@3.2.47)
       autoprefixer: 10.4.14(postcss@8.4.21)
@@ -1959,7 +1922,7 @@ packages:
       postcss: 8.4.21
       postcss-import: 15.1.0(postcss@8.4.21)
       postcss-url: 10.1.3(postcss@8.4.21)
-      rollup-plugin-visualizer: 5.9.0(rollup@2.79.1)
+      rollup-plugin-visualizer: 5.9.0
       std-env: 3.3.2
       strip-literal: 1.0.1
       ufo: 1.1.1
@@ -2027,10 +1990,10 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxtjs/google-fonts@3.0.0(rollup@2.79.1):
+  /@nuxtjs/google-fonts@3.0.0:
     resolution: {integrity: sha512-knP2CJFkMHGQ9pepVNwquXvqiIHDma/6yZNXiYk7WWatRbbQUPf2423vXiBYu267Mff2KMuDLoAJ1Dsv2ymhdQ==}
     dependencies:
-      '@nuxt/kit': 3.4.1(rollup@2.79.1)
+      '@nuxt/kit': 3.4.1
       google-fonts-helper: 3.2.4
       pathe: 1.1.0
     transitivePeerDependencies:
@@ -2038,10 +2001,10 @@ packages:
       - supports-color
     dev: true
 
-  /@pinia/nuxt@0.4.8(rollup@2.79.1)(typescript@5.0.4)(vue@3.2.47):
+  /@pinia/nuxt@0.4.8(typescript@5.0.4)(vue@3.2.47):
     resolution: {integrity: sha512-E0HKmW+6Ec5HYzomZl86xil2rGPRAqKG1d+slVVLBHC7PFZOM0VIw/1XFO9hwo+EiCuDEXZDReZwTqO7KQsMgQ==}
     dependencies:
-      '@nuxt/kit': 3.1.2(rollup@2.79.1)
+      '@nuxt/kit': 3.1.2
       pinia: 2.0.34(typescript@5.0.4)(vue@3.2.47)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -2198,7 +2161,7 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-replace@5.0.2(rollup@2.79.1):
+  /@rollup/plugin-replace@5.0.2:
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2207,9 +2170,8 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
+      '@rollup/pluginutils': 5.0.2
       magic-string: 0.27.0
-      rollup: 2.79.1
     dev: true
 
   /@rollup/plugin-replace@5.0.2(rollup@3.20.2):
@@ -2273,7 +2235,7 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@rollup/pluginutils@5.0.2(rollup@2.79.1):
+  /@rollup/pluginutils@5.0.2:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2285,7 +2247,6 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 2.79.1
     dev: true
 
   /@rollup/pluginutils@5.0.2(rollup@3.20.2):
@@ -2739,14 +2700,16 @@ packages:
       - supports-color
     dev: true
 
-  /@vite-pwa/nuxt@0.0.7(@nuxt/kit@3.4.1)(vite-plugin-pwa@0.14.7):
+  /@vite-pwa/nuxt@0.0.7:
     resolution: {integrity: sha512-7bUTHbameF4GMLQjuyICB761YTC2/Zp6s+rd3hz63Q8lUHP/WUkvOhkoqAoA7CrRPrM85QDeOJKBEvailDb5+w==}
-    peerDependencies:
-      '@nuxt/kit': ^3.0.0 || ^3.1.0
-      vite-plugin-pwa: ^0.14.0
     dependencies:
-      '@nuxt/kit': 3.4.1(rollup@2.79.1)
-      vite-plugin-pwa: 0.14.7(vite@4.2.1)(workbox-build@6.5.4)(workbox-window@6.5.4)
+      '@nuxt/kit': 3.4.1
+      vite-plugin-pwa: 0.14.7
+    transitivePeerDependencies:
+      - '@types/babel__core'
+      - rollup
+      - supports-color
+      - vite
     dev: true
 
   /@vitejs/plugin-vue-jsx@3.0.1(vite@4.2.1)(vue@3.2.47):
@@ -2827,17 +2790,6 @@ packages:
       muggle-string: 0.2.2
     dev: true
 
-  /@vue-macros/api@0.5.1(rollup@2.79.1)(vue@3.2.47):
-    resolution: {integrity: sha512-2rpldQa5YnSY4+auFSZLQDXHL31z9VyIA/I0AqcXzxO2TRfZewhNGY5I/K/nuaheXCumodFxbCPXGZ6CKa6lRA==}
-    engines: {node: '>=14.19.0'}
-    dependencies:
-      '@babel/types': 7.21.4
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
-    transitivePeerDependencies:
-      - rollup
-      - vue
-    dev: true
-
   /@vue-macros/api@0.5.1(rollup@3.20.2)(vue@3.2.47):
     resolution: {integrity: sha512-2rpldQa5YnSY4+auFSZLQDXHL31z9VyIA/I0AqcXzxO2TRfZewhNGY5I/K/nuaheXCumodFxbCPXGZ6CKa6lRA==}
     engines: {node: '>=14.19.0'}
@@ -2849,35 +2801,27 @@ packages:
       - vue
     dev: true
 
-  /@vue-macros/better-define@1.5.1(rollup@2.79.1)(vue@3.2.47):
-    resolution: {integrity: sha512-MaYvAvbvgw3aJkY+ct52FZIQwJ8R/0vbDqcVdhT9ux94pVqRYWyd04j+vGo4prizo58FZiE+hZ1NBmAvT27aQA==}
+  /@vue-macros/api@0.5.1(vue@3.2.47):
+    resolution: {integrity: sha512-2rpldQa5YnSY4+auFSZLQDXHL31z9VyIA/I0AqcXzxO2TRfZewhNGY5I/K/nuaheXCumodFxbCPXGZ6CKa6lRA==}
     engines: {node: '>=14.19.0'}
     dependencies:
-      '@vue-macros/api': 0.5.1(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
-      unplugin: 1.3.1
+      '@babel/types': 7.21.4
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
     transitivePeerDependencies:
       - rollup
       - vue
     dev: true
 
-  /@vue-macros/common@1.2.0(rollup@2.79.1)(vue@3.2.47):
-    resolution: {integrity: sha512-lQglnRn+8wkdAhmGQbrI0mo4SzRuY5KBjst0qi8LBDYllFKtI2brapbewUME1AXnXbVett0SRDnB2EdZXyzCmw==}
+  /@vue-macros/better-define@1.5.1(vue@3.2.47):
+    resolution: {integrity: sha512-MaYvAvbvgw3aJkY+ct52FZIQwJ8R/0vbDqcVdhT9ux94pVqRYWyd04j+vGo4prizo58FZiE+hZ1NBmAvT27aQA==}
     engines: {node: '>=14.19.0'}
-    peerDependencies:
-      vue: ^2.7.0 || ^3.2.25
-    peerDependenciesMeta:
-      vue:
-        optional: true
     dependencies:
-      '@babel/types': 7.21.4
-      '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
-      '@vue/compiler-sfc': 3.3.0-alpha.9
-      local-pkg: 0.4.3
-      magic-string-ast: 0.1.2
-      vue: 3.2.47
+      '@vue-macros/api': 0.5.1(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
+      unplugin: 1.3.1
     transitivePeerDependencies:
       - rollup
+      - vue
     dev: true
 
   /@vue-macros/common@1.2.0(rollup@3.20.2)(vue@3.2.47):
@@ -2899,7 +2843,26 @@ packages:
       - rollup
     dev: true
 
-  /@vue-macros/define-models@1.0.1(@vueuse/core@10.0.0)(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/common@1.2.0(vue@3.2.47):
+    resolution: {integrity: sha512-lQglnRn+8wkdAhmGQbrI0mo4SzRuY5KBjst0qi8LBDYllFKtI2brapbewUME1AXnXbVett0SRDnB2EdZXyzCmw==}
+    engines: {node: '>=14.19.0'}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.2.25
+    peerDependenciesMeta:
+      vue:
+        optional: true
+    dependencies:
+      '@babel/types': 7.21.4
+      '@rollup/pluginutils': 5.0.2
+      '@vue/compiler-sfc': 3.3.0-alpha.9
+      local-pkg: 0.4.3
+      magic-string-ast: 0.1.2
+      vue: 3.2.47
+    transitivePeerDependencies:
+      - rollup
+    dev: true
+
+  /@vue-macros/define-models@1.0.1(@vueuse/core@10.0.0)(vue@3.2.47):
     resolution: {integrity: sha512-/Xs7IE9hMD0939sKuBxTnQDDcjcSug61cnIt+owIB9sWvXYNdagjL5fsvMmR6ErqXqfswbUuhbTtxZeJXpVn/g==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
@@ -2908,7 +2871,7 @@ packages:
       '@vueuse/core':
         optional: true
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       '@vueuse/core': 10.0.0(vue@3.2.47)
       ast-walker-scope: 0.4.1
       unplugin: 1.3.1
@@ -2917,61 +2880,75 @@ packages:
       - vue
     dev: true
 
-  /@vue-macros/define-props-refs@1.0.0(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/define-props-refs@1.0.0(vue@3.2.47):
     resolution: {integrity: sha512-XlM0ljUl1bxvNP/KuiV6IJhECcoEel9GuZwzqyCvoZFVkdVyjBbYjxwoHI8UEwm5mxITYHiHpdmhQk33EauJ2g==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
       vue: ^2.7.0 || ^3.2.25
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       unplugin: 1.3.1
       vue: 3.2.47
     transitivePeerDependencies:
       - rollup
     dev: true
 
-  /@vue-macros/define-props@1.0.3(@vue-macros/reactivity-transform@0.3.4)(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/define-props@1.0.3(@vue-macros/reactivity-transform@0.3.4)(vue@3.2.47):
     resolution: {integrity: sha512-OE41zT/5XVTubxIo7BrCmx+pMcwz6SQQ3ujVmoyDE8Kj+GwVBM8cWkRZxHeD5Bwli9jrc2hY/iNoBhKxO/iulA==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
       '@vue-macros/reactivity-transform': ^0.3.4
       vue: ^2.7.0 || ^3.2.25
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/reactivity-transform': 0.3.4(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
+      '@vue-macros/reactivity-transform': 0.3.4(vue@3.2.47)
       unplugin: 1.3.1
       vue: 3.2.47
     transitivePeerDependencies:
       - rollup
     dev: true
 
-  /@vue-macros/define-render@1.3.4(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/define-props@1.0.3(vue@3.2.47):
+    resolution: {integrity: sha512-OE41zT/5XVTubxIo7BrCmx+pMcwz6SQQ3ujVmoyDE8Kj+GwVBM8cWkRZxHeD5Bwli9jrc2hY/iNoBhKxO/iulA==}
+    engines: {node: '>=14.19.0'}
+    peerDependencies:
+      '@vue-macros/reactivity-transform': ^0.3.4
+      vue: ^2.7.0 || ^3.2.25
+    dependencies:
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
+      unplugin: 1.3.1
+      vue: 3.2.47
+    transitivePeerDependencies:
+      - rollup
+    dev: true
+
+  /@vue-macros/define-render@1.3.4(vue@3.2.47):
     resolution: {integrity: sha512-dS9vUNXKpkOvSb0wVKz2bdxkAWXnZSxMzXTXjAy5oiib9MaR+a4znKhrK/WIx39bR5OI1zEGqQY0s0lzWEbvGA==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
       vue: ^2.7.0 || ^3.0.0
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       unplugin: 1.3.1
       vue: 3.2.47
     transitivePeerDependencies:
       - rollup
     dev: true
 
-  /@vue-macros/define-slots@1.0.0(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/define-slots@1.0.0(vue@3.2.47):
     resolution: {integrity: sha512-Mrpkt/iYCABXc5OBwuyk+twbr39Tru49Lg6rhg3qxl910loiQVIXuOzlP4Ftr4V7PIL3gsiLvH+d+5T7DIzc6w==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
       vue: ^2.7.0 || ^3.0.0
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       unplugin: 1.3.1
       vue: 3.2.47
     transitivePeerDependencies:
       - rollup
     dev: true
 
-  /@vue-macros/devtools@0.1.2(vite@4.2.1):
+  /@vue-macros/devtools@0.1.2:
     resolution: {integrity: sha512-LhWTb0pPoTcFmK8GZb80+q83ypEK8QS1sS2i+kKbrfvjTYnb4wQ6W3ee53WHX9+sC/Tm3HNmzhjWEBQO0Ybcqg==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
@@ -2981,39 +2958,38 @@ packages:
         optional: true
     dependencies:
       sirv: 2.0.2
-      vite: 4.2.1(@types/node@18.15.11)(sass@1.62.0)
       vue: 3.2.47
     dev: true
 
-  /@vue-macros/export-props@0.3.3(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/export-props@0.3.3(vue@3.2.47):
     resolution: {integrity: sha512-HDWuEaJrckufx8DohwTFmAtVgOeJomglIYJmc2g9tKAF6NF6p7PE24U2xl/FgoQs/vQdZyJYoeHUUR4TosKE/w==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
       vue: ^2.7.0 || ^3.2.25
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       unplugin: 1.3.1
       vue: 3.2.47
     transitivePeerDependencies:
       - rollup
     dev: true
 
-  /@vue-macros/hoist-static@1.3.3(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/hoist-static@1.3.3(vue@3.2.47):
     resolution: {integrity: sha512-6MF6i69J4VOUf9/FSbcyHAq55cneeRyPeptf5LyrOHZ7CVjTDE0EhMtsecSYMs/aMM2pUtkBpRAy9UKGRiTmGA==}
     engines: {node: '>=14.19.0'}
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       unplugin: 1.3.1
     transitivePeerDependencies:
       - rollup
       - vue
     dev: true
 
-  /@vue-macros/named-template@0.3.4(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/named-template@0.3.4(vue@3.2.47):
     resolution: {integrity: sha512-SIMoA/QG5Wy7wPMgJF+QDZjcVp9oayw5etAeVyeeaspSH9EXYWeO12psiR/UBz1bZMpolTo20IgeYXL3EYOtfA==}
     engines: {node: '>=14.19.0'}
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       '@vue/compiler-dom': 3.3.0-alpha.9
       unplugin: 1.3.1
     transitivePeerDependencies:
@@ -3021,18 +2997,18 @@ packages:
       - vue
     dev: true
 
-  /@vue-macros/nuxt@1.2.8(@vue-macros/reactivity-transform@0.3.4)(@vueuse/core@10.0.0)(nuxt@3.4.1)(rollup@2.79.1)(vite@4.2.1)(vue@3.2.47):
+  /@vue-macros/nuxt@1.2.8(@vueuse/core@10.0.0)(nuxt@3.4.1)(vue@3.2.47):
     resolution: {integrity: sha512-dSM2mIguadR3kZSM0TbhD2fVHk4qld4vAs16rIx0BIvvvnB1060LcHJ8dOxBOY7W49LEZ98tCLDw826EDUzezA==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
       nuxt: ^3.0.0
     dependencies:
-      '@nuxt/kit': 3.4.1(rollup@2.79.1)
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/short-vmodel': 1.2.4(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/volar': 0.9.5(@vue-macros/reactivity-transform@0.3.4)(rollup@2.79.1)(vue@3.2.47)
-      nuxt: 3.4.1(@types/node@18.15.11)(eslint@8.38.0)(rollup@2.79.1)(sass@1.62.0)(typescript@5.0.4)
-      unplugin-vue-macros: 2.0.0(@vueuse/core@10.0.0)(rollup@2.79.1)(vite@4.2.1)(vue@3.2.47)
+      '@nuxt/kit': 3.4.1
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
+      '@vue-macros/short-vmodel': 1.2.4(vue@3.2.47)
+      '@vue-macros/volar': 0.9.5(vue@3.2.47)
+      nuxt: 3.4.1(@types/node@18.15.11)(eslint@8.38.0)(sass@1.62.0)(typescript@5.0.4)
+      unplugin-vue-macros: 2.0.0(@vueuse/core@10.0.0)(vue@3.2.47)
     transitivePeerDependencies:
       - '@vue-macros/reactivity-transform'
       - '@vueuse/core'
@@ -3045,14 +3021,14 @@ packages:
       - webpack
     dev: true
 
-  /@vue-macros/reactivity-transform@0.3.4(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/reactivity-transform@0.3.4(vue@3.2.47):
     resolution: {integrity: sha512-XP0027Va90bG3Unz/UCuEAnOqUKdJIuFyB2cLKrdeIsVscjguGDA9uc8M0+G9vD7odK6Mv7fkhNKDW+C7cwVhQ==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
       vue: ^2.7.0 || ^3.2.25
     dependencies:
       '@babel/parser': 7.21.4
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       '@vue/compiler-core': 3.3.0-alpha.9
       '@vue/shared': 3.3.0-alpha.9
       magic-string: 0.30.0
@@ -3062,11 +3038,11 @@ packages:
       - rollup
     dev: true
 
-  /@vue-macros/setup-block@0.2.3(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/setup-block@0.2.3(vue@3.2.47):
     resolution: {integrity: sha512-P2JObNRDA7sXhnqrtbaltJHAHAQmPbs9KIaWZPWxV/DjwiLSq1reCcZ2SByZHB4QC8pM6Wp6J4jHn+Qu3VTmoA==}
     engines: {node: '>=14.19.0'}
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       '@vue/compiler-dom': 3.3.0-alpha.9
       unplugin: 1.3.1
     transitivePeerDependencies:
@@ -3074,44 +3050,44 @@ packages:
       - vue
     dev: true
 
-  /@vue-macros/setup-component@0.16.4(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/setup-component@0.16.4(vue@3.2.47):
     resolution: {integrity: sha512-5Y7qCCyLaVXxQGxtMX38rSKyDUu7efiPNAS52zX5fUQzfj2Udgy2/Kdik2TP5HhvMF94iXCjAZVCOUHTQMJxlA==}
     engines: {node: '>=14.19.0'}
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       unplugin: 1.3.1
     transitivePeerDependencies:
       - rollup
       - vue
     dev: true
 
-  /@vue-macros/setup-sfc@0.15.4(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/setup-sfc@0.15.4(vue@3.2.47):
     resolution: {integrity: sha512-qrjx7QN9JILflfVVICidC3zhJ+ZhEkY+7UTEfYYwWmn1FqGmAahAgVd+t60M7iEy62+c5kS5azPQgyN3f0UtCw==}
     engines: {node: '>=14.19.0'}
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       unplugin: 1.3.1
     transitivePeerDependencies:
       - rollup
       - vue
     dev: true
 
-  /@vue-macros/short-emits@1.3.3(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/short-emits@1.3.3(vue@3.2.47):
     resolution: {integrity: sha512-8A38YgdoJQGvrsZFGbFiO6kOoAUuBs7Pe10g9eT2NhKoi/PVy+YrM/0oS1nlyH+sXgEVzDLJniqmwZ6Ggvg+pQ==}
     engines: {node: '>=14.19.0'}
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       unplugin: 1.3.1
     transitivePeerDependencies:
       - rollup
       - vue
     dev: true
 
-  /@vue-macros/short-vmodel@1.2.4(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/short-vmodel@1.2.4(vue@3.2.47):
     resolution: {integrity: sha512-CInkaf9iW5vQUhUsiu+uQ80siFPnN1rgiMZJ+l0F1fQcUmeHiIANZjw7E2ryK7lh6ZmF7vLHW1RCo1KeGgoGqg==}
     engines: {node: '>=14.19.0'}
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       '@vue/compiler-core': 3.3.0-alpha.9
     transitivePeerDependencies:
       - rollup
@@ -3131,7 +3107,7 @@ packages:
       vue: 3.2.47
     dev: true
 
-  /@vue-macros/volar@0.9.5(@vue-macros/reactivity-transform@0.3.4)(rollup@2.79.1)(vue@3.2.47):
+  /@vue-macros/volar@0.9.5(vue@3.2.47):
     resolution: {integrity: sha512-+alRBRwezUWHrZZ0sxI4RUQVtkkvS7jX4v6XO26VoT0/oUmgyffuhG6ahRWJicbHajBhXqruzTGWAVR26QhEyQ==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
@@ -3141,9 +3117,9 @@ packages:
         optional: true
     dependencies:
       '@volar/language-core': 1.4.0-alpha.5
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/define-props': 1.0.3(@vue-macros/reactivity-transform@0.3.4)(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/short-vmodel': 1.2.4(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
+      '@vue-macros/define-props': 1.0.3(vue@3.2.47)
+      '@vue-macros/short-vmodel': 1.2.4(vue@3.2.47)
       muggle-string: 0.2.2
     transitivePeerDependencies:
       - '@vue-macros/reactivity-transform'
@@ -3339,16 +3315,16 @@ packages:
     resolution: {integrity: sha512-7Rh6tcs6aYLRLSdDHF+74wWP0Y1zLwpNJszKAIqlNBrmqdbkz8yh6NtjCYvXrrW6g+FU3ZWvR7F5ASNls+bHmw==}
     dev: true
 
-  /@vueuse/nuxt@10.0.0(nuxt@3.4.1)(rollup@2.79.1)(vue@3.2.47):
+  /@vueuse/nuxt@10.0.0(nuxt@3.4.1)(vue@3.2.47):
     resolution: {integrity: sha512-u1MU9eNpDg7MsTgz1DlF2RaCw2E/KMG17Xb/2wnnK4G65d1xgQiF4mb28W4Qkz9rs56GCSpgJss0g4y5U8LG4g==}
     peerDependencies:
       nuxt: ^3.0.0
     dependencies:
-      '@nuxt/kit': 3.4.1(rollup@2.79.1)
+      '@nuxt/kit': 3.4.1
       '@vueuse/core': 10.0.0(vue@3.2.47)
       '@vueuse/metadata': 10.0.0
       local-pkg: 0.4.3
-      nuxt: 3.4.1(@types/node@18.15.11)(eslint@8.38.0)(rollup@2.79.1)(sass@1.62.0)(typescript@5.0.4)
+      nuxt: 3.4.1(@types/node@18.15.11)(eslint@8.38.0)(sass@1.62.0)(typescript@5.0.4)
       vue-demi: 0.14.0(vue@3.2.47)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -3374,7 +3350,7 @@ packages:
       eslint: 8.38.0
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.38.0)
       eslint-plugin-html: 7.1.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.50.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.38.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.58.0)(eslint@8.38.0)
       eslint-plugin-jsonc: 2.7.0(eslint@8.38.0)
       eslint-plugin-markdown: 3.0.0(eslint@8.38.0)
       eslint-plugin-n: 15.7.0(eslint@8.38.0)
@@ -3435,7 +3411,7 @@ packages:
       eslint: 8.38.0
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.38.0)
       eslint-plugin-html: 7.1.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.50.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.38.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.58.0)(eslint@8.38.0)
       eslint-plugin-jsonc: 2.7.0(eslint@8.38.0)
       eslint-plugin-n: 15.7.0(eslint@8.38.0)
       eslint-plugin-promise: 6.1.1(eslint@8.38.0)
@@ -4888,6 +4864,35 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.58.0)(eslint-import-resolver-node@0.3.7)(eslint@8.38.0):
+    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.58.0(eslint@8.38.0)(typescript@5.0.4)
+      debug: 3.2.7
+      eslint: 8.38.0
+      eslint-import-resolver-node: 0.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-plugin-es@3.0.1(eslint@8.38.0):
     resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
@@ -4946,6 +4951,39 @@ packages:
       eslint: 8.38.0
       eslint-import-resolver-node: 0.3.7
       eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.50.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.38.0)
+      has: 1.0.3
+      is-core-module: 2.11.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.6
+      resolve: 1.22.1
+      semver: 6.3.0
+      tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.58.0)(eslint@8.38.0):
+    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.58.0(eslint@8.38.0)(typescript@5.0.4)
+      array-includes: 3.1.6
+      array.prototype.flat: 1.3.1
+      array.prototype.flatmap: 1.3.1
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.38.0
+      eslint-import-resolver-node: 0.3.7
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.58.0)(eslint-import-resolver-node@0.3.7)(eslint@8.38.0)
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -6895,8 +6933,8 @@ packages:
     hasBin: true
     dev: true
 
-  /mkdirp@2.1.6:
-    resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
+  /mkdirp@3.0.0:
+    resolution: {integrity: sha512-7+JDnNsyCvZXoUJdkMR0oUE2AmAdsNXGTmRbiOjYIwQ6q+bL6NwrozGQdPcmYaNcrhH37F50HHBUzoaBV6FITQ==}
     engines: {node: '>=10'}
     hasBin: true
     dev: true
@@ -7161,10 +7199,10 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /nuxt-config-schema@0.4.5(rollup@2.79.1):
+  /nuxt-config-schema@0.4.5:
     resolution: {integrity: sha512-Y5anu5puDfMJfDP7IYjXsn6Dvj262HtjZqa73jCBbFRCc5jnjrs+BEpJJmtPG32ZsqzO2+RL4oTNb3H6IfKZLQ==}
     dependencies:
-      '@nuxt/kit': 3.4.1(rollup@2.79.1)
+      '@nuxt/kit': 3.4.1
       changelogen: 0.4.1
       defu: 6.1.2
       jiti: 1.18.2
@@ -7175,27 +7213,27 @@ packages:
       - supports-color
     dev: true
 
-  /nuxt-icon@0.3.3(rollup@2.79.1)(vue@3.2.47):
+  /nuxt-icon@0.3.3(vue@3.2.47):
     resolution: {integrity: sha512-KdhJAigBGTP8/YIFZ3orwetk40AgLq6VQ5HRYuDLmv5hiDptor9Ro+WIdZggHw7nciRxZvDdQkEwi9B5G/jrkQ==}
     dependencies:
       '@iconify/vue': 4.1.1(vue@3.2.47)
-      '@nuxt/kit': 3.4.1(rollup@2.79.1)
-      nuxt-config-schema: 0.4.5(rollup@2.79.1)
+      '@nuxt/kit': 3.4.1
+      nuxt-config-schema: 0.4.5
     transitivePeerDependencies:
       - rollup
       - supports-color
       - vue
     dev: true
 
-  /nuxt-typed-router@3.1.3(rollup@2.79.1):
-    resolution: {integrity: sha512-+GCJk+1y7nQVFK9mXn/Kcm9jO2DWCuXaPhSlz4t8TL2HPc2G7u+QanZdcI7AF0k2ARAvrVs5AOrw7Wt/rG+lIg==}
+  /nuxt-typed-router@3.1.4:
+    resolution: {integrity: sha512-OfqVehSOYxkz1h93jxzSxLlfkdnZiMeA9s76KZe2sVe/mN7DbRJ+EVVaFxYHNFJwp7CA91kFmWKKJeE/RvSFmA==}
     dependencies:
-      '@nuxt/kit': 3.4.1(rollup@2.79.1)
+      '@nuxt/kit': 3.4.1
       chalk: 5.2.0
       defu: 6.1.2
       lodash-es: 4.17.21
       log-symbols: 5.1.0
-      mkdirp: 2.1.6
+      mkdirp: 3.0.0
       nanoid: 4.0.2
       pathe: 1.1.0
       prettier: 2.8.7
@@ -7204,7 +7242,7 @@ packages:
       - supports-color
     dev: true
 
-  /nuxt@3.4.1(@types/node@18.15.11)(eslint@8.38.0)(rollup@2.79.1)(sass@1.62.0)(typescript@5.0.4):
+  /nuxt@3.4.1(@types/node@18.15.11)(eslint@8.38.0)(sass@1.62.0)(typescript@5.0.4):
     resolution: {integrity: sha512-wKT5iZebO1D7QtAN1fDNNsjaTFbAC5pO4kWzw2qX2OOg2SWP/k42sCfxbcz/JkLL4FJVwpya+9OD9/2MwEdt1g==}
     engines: {node: ^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     hasBin: true
@@ -7212,11 +7250,11 @@ packages:
       '@types/node': ^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
       '@nuxt/devalue': 2.0.0
-      '@nuxt/kit': 3.4.1(rollup@2.79.1)
-      '@nuxt/schema': 3.4.1(rollup@2.79.1)
-      '@nuxt/telemetry': 2.2.0(rollup@2.79.1)
+      '@nuxt/kit': 3.4.1
+      '@nuxt/schema': 3.4.1
+      '@nuxt/telemetry': 2.2.0
       '@nuxt/ui-templates': 1.1.1
-      '@nuxt/vite-builder': 3.4.1(@types/node@18.15.11)(eslint@8.38.0)(rollup@2.79.1)(sass@1.62.0)(typescript@5.0.4)(vue@3.2.47)
+      '@nuxt/vite-builder': 3.4.1(@types/node@18.15.11)(eslint@8.38.0)(sass@1.62.0)(typescript@5.0.4)(vue@3.2.47)
       '@types/node': 18.15.11
       '@unhead/ssr': 1.1.25
       '@unhead/vue': 1.1.25(vue@3.2.47)
@@ -7252,7 +7290,7 @@ packages:
       ufo: 1.1.1
       unctx: 2.2.0
       unenv: 1.3.1
-      unimport: 3.0.6(rollup@2.79.1)
+      unimport: 3.0.6
       unplugin: 1.3.1
       untyped: 1.3.2
       vue: 3.2.47
@@ -8248,7 +8286,7 @@ packages:
       terser: 5.16.3
     dev: true
 
-  /rollup-plugin-visualizer@5.9.0(rollup@2.79.1):
+  /rollup-plugin-visualizer@5.9.0:
     resolution: {integrity: sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==}
     engines: {node: '>=14'}
     hasBin: true
@@ -8260,7 +8298,6 @@ packages:
     dependencies:
       open: 8.4.0
       picomatch: 2.3.1
-      rollup: 2.79.1
       source-map: 0.7.4
       yargs: 17.6.2
     dev: true
@@ -9045,10 +9082,10 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /unimport@2.1.0(rollup@2.79.1):
+  /unimport@2.1.0:
     resolution: {integrity: sha512-GDVIxATluUquX8EqelT6DtnmnZaXGID1jsO9IXwlnxb0OIEqKAxTOnTlnGmHbseoGTh+ZC9kcNDaO18HYQj9KA==}
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
+      '@rollup/pluginutils': 5.0.2
       escape-string-regexp: 5.0.0
       fast-glob: 3.2.12
       local-pkg: 0.4.3
@@ -9063,10 +9100,10 @@ packages:
       - rollup
     dev: true
 
-  /unimport@3.0.6(rollup@2.79.1):
+  /unimport@3.0.6:
     resolution: {integrity: sha512-GYxGJ1Bri1oqx8VFDjdgooGzeK7jBk3bvhXmamTIpu3nONOcUMGwZbX7X0L5RA7OWMXpR4vzpSQP7pXUzJg1/Q==}
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
+      '@rollup/pluginutils': 5.0.2
       escape-string-regexp: 5.0.0
       fast-glob: 3.2.12
       local-pkg: 0.4.3
@@ -9117,7 +9154,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unplugin-combine@0.6.0(rollup@2.79.1)(vite@4.2.1):
+  /unplugin-combine@0.6.0:
     resolution: {integrity: sha512-cZkTg2Z3CcScyRi6QtpVxBZoCMsPaEHyKNh7HyqMkfWV7sKNwHllYezVOFINOGNzqSS1+xWLY3iDCiTVoH3oaA==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
@@ -9136,16 +9173,14 @@ packages:
         optional: true
     dependencies:
       '@antfu/utils': 0.7.2
-      rollup: 2.79.1
       unplugin: 1.3.1
-      vite: 4.2.1(@types/node@18.15.11)(sass@1.62.0)
     dev: true
 
-  /unplugin-vue-define-options@1.3.3(rollup@2.79.1)(vue@3.2.47):
+  /unplugin-vue-define-options@1.3.3(vue@3.2.47):
     resolution: {integrity: sha512-gSBR84QJZUYhiLlQzJ8dQ9BCUAnnfWf+sTqhxXpzoL/nWH3sQqlGWznQtUPKTqQZdupQr1DCIVvLYMQD1/4X6g==}
     engines: {node: '>=14.19.0'}
     dependencies:
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
       ast-walker-scope: 0.4.1
       unplugin: 1.3.1
     transitivePeerDependencies:
@@ -9153,32 +9188,32 @@ packages:
       - vue
     dev: true
 
-  /unplugin-vue-macros@2.0.0(@vueuse/core@10.0.0)(rollup@2.79.1)(vite@4.2.1)(vue@3.2.47):
+  /unplugin-vue-macros@2.0.0(@vueuse/core@10.0.0)(vue@3.2.47):
     resolution: {integrity: sha512-9mNroRGPnZVCfvIxf7V+ixBPYvK643xZ2jKSiuDbyc1zv9x3qU9Oq+BpVg4K0Gw/51VzKc3MkWcGkemIB1nMHA==}
     engines: {node: '>=14.19.0'}
     peerDependencies:
       vue: ^2.7.0 || ^3.2.25
     dependencies:
-      '@vue-macros/better-define': 1.5.1(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/common': 1.2.0(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/define-models': 1.0.1(@vueuse/core@10.0.0)(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/define-props': 1.0.3(@vue-macros/reactivity-transform@0.3.4)(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/define-props-refs': 1.0.0(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/define-render': 1.3.4(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/define-slots': 1.0.0(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/devtools': 0.1.2(vite@4.2.1)
-      '@vue-macros/export-props': 0.3.3(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/hoist-static': 1.3.3(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/named-template': 0.3.4(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/reactivity-transform': 0.3.4(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/setup-block': 0.2.3(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/setup-component': 0.16.4(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/setup-sfc': 0.15.4(rollup@2.79.1)(vue@3.2.47)
-      '@vue-macros/short-emits': 1.3.3(rollup@2.79.1)(vue@3.2.47)
+      '@vue-macros/better-define': 1.5.1(vue@3.2.47)
+      '@vue-macros/common': 1.2.0(vue@3.2.47)
+      '@vue-macros/define-models': 1.0.1(@vueuse/core@10.0.0)(vue@3.2.47)
+      '@vue-macros/define-props': 1.0.3(@vue-macros/reactivity-transform@0.3.4)(vue@3.2.47)
+      '@vue-macros/define-props-refs': 1.0.0(vue@3.2.47)
+      '@vue-macros/define-render': 1.3.4(vue@3.2.47)
+      '@vue-macros/define-slots': 1.0.0(vue@3.2.47)
+      '@vue-macros/devtools': 0.1.2
+      '@vue-macros/export-props': 0.3.3(vue@3.2.47)
+      '@vue-macros/hoist-static': 1.3.3(vue@3.2.47)
+      '@vue-macros/named-template': 0.3.4(vue@3.2.47)
+      '@vue-macros/reactivity-transform': 0.3.4(vue@3.2.47)
+      '@vue-macros/setup-block': 0.2.3(vue@3.2.47)
+      '@vue-macros/setup-component': 0.16.4(vue@3.2.47)
+      '@vue-macros/setup-sfc': 0.15.4(vue@3.2.47)
+      '@vue-macros/short-emits': 1.3.3(vue@3.2.47)
       '@vue-macros/single-define': 0.1.4(vue@3.2.47)
       unplugin: 1.3.1
-      unplugin-combine: 0.6.0(rollup@2.79.1)(vite@4.2.1)
-      unplugin-vue-define-options: 1.3.3(rollup@2.79.1)(vue@3.2.47)
+      unplugin-combine: 0.6.0
+      unplugin-vue-define-options: 1.3.3(vue@3.2.47)
       vue: 3.2.47
     transitivePeerDependencies:
       - '@vueuse/core'
@@ -9241,7 +9276,7 @@ packages:
   /untyped@1.2.2:
     resolution: {integrity: sha512-EANYd5L6AdpgfldlgMcmvOOnj092nWhy0ybhc7uhEH12ipytDYz89EOegBQKj8qWL3u1wgYnmFjADhsuCJs5Aw==}
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.4
       '@babel/standalone': 7.20.15
       '@babel/types': 7.20.7
       scule: 1.0.0
@@ -9370,22 +9405,20 @@ packages:
       vscode-uri: 3.0.7
     dev: true
 
-  /vite-plugin-pwa@0.14.7(vite@4.2.1)(workbox-build@6.5.4)(workbox-window@6.5.4):
+  /vite-plugin-pwa@0.14.7:
     resolution: {integrity: sha512-dNJaf0fYOWncmjxv9HiSa2xrSjipjff7IkYE5oIUJ2x5HKu3cXgA8LRgzOwTc5MhwyFYRSU0xyN0Phbx3NsQYw==}
     peerDependencies:
       vite: ^3.1.0 || ^4.0.0
-      workbox-build: ^6.5.4
-      workbox-window: ^6.5.4
     dependencies:
       '@rollup/plugin-replace': 5.0.2(rollup@3.20.2)
       debug: 4.3.4
       fast-glob: 3.2.12
       pretty-bytes: 6.1.0
       rollup: 3.20.2
-      vite: 4.2.1(@types/node@18.15.11)(sass@1.62.0)
       workbox-build: 6.5.4
       workbox-window: 6.5.4
     transitivePeerDependencies:
+      - '@types/babel__core'
       - supports-color
     dev: true
 


### PR DESCRIPTION
Hi!

`nuxt-typed-router` module maintainer here. Saw your project was using my module and the latest version of Nuxt (3.4.1)

Nuxt 3.4.0 introduced a breaking change in how it generate the route paths (reference this bug in my repo https://github.com/victorgarciaesgi/nuxt-typed-router/issues/85), casually breaking how the type route params are generated.
I updated my module to support the new path syntax in `v3.1.4`
Your base project isn't using params so it shouldn't be impacting you but users depending or creating on it could, so better to update! :D 
